### PR TITLE
Update mzML1.1.1.xsd to use declared namespace

### DIFF
--- a/schema/schema_1.1/mzML1.1.1.xsd
+++ b/schema/schema_1.1/mzML1.1.1.xsd
@@ -542,11 +542,11 @@
           <xs:annotation>
             <xs:documentation>A unique string identifier for this run.</xs:documentation>
           </xs:annotation>
-          <xsd:simpleType>
-              <xsd:restriction base="xsd:string">
-                  <xsd:minLength value="1"/>
-              </xsd:restriction>
-          </xsd:simpleType>
+          <xs:simpleType>
+              <xs:restriction base="xs:string">
+                  <xs:minLength value="1"/>
+              </xs:restriction>
+          </xs:simpleType>
         </xs:attribute>
         <xs:attribute name="defaultInstrumentConfigurationRef" type="xs:IDREF" use="required">
           <xs:annotation>


### PR DESCRIPTION
The document declares the `XMLSchema` namespace `xs`, not `xsd`, but the addition for v1.1.1 used `xsd` when creating the new schema elements. This lead to an error when parsing the document strictly. 

This change fixes the namespace on the added tags.